### PR TITLE
Bump hugo to latest version 0.140.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates to GitHub Actions once per week
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 24
     - name: Deploy
       run: chmod 755 ./deploy.sh && ./deploy.sh
     - name: Generate

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # frp-site
 
-The website of frp.
+Workflow for automated generation and deployment of [frp website]().

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@ if [ -d "./frp-doc" ]; then
     cd ./frp-doc
     git pull
 else
-    git clone --recurse-submodules --depth 1 https://github.com/gofrp/frp-doc.git frp-doc
+    git clone --depth 1 https://github.com/gofrp/frp-doc.git frp-doc
 fi
 
 cd $SITE_ROOT

--- a/generate.sh
+++ b/generate.sh
@@ -4,8 +4,8 @@ SITE_ROOT=`pwd`
 cd ./source
 npm install
 
-wget https://github.com/gohugoio/hugo/releases/download/v0.133.1/hugo_extended_0.133.1_Linux-64bit.tar.gz
-tar -zxvf ./hugo_extended_0.133.1_Linux-64bit.tar.gz
+wget https://github.com/gohugoio/hugo/releases/download/v0.140.2/hugo_extended_0.140.2_Linux-64bit.tar.gz
+tar -zxvf ./hugo_extended_0.140.2_Linux-64bit.tar.gz
 ./hugo
 
 if [ -d "./public" ]; then


### PR DESCRIPTION
This PR bumps hugo to latest version 0.140.2.
This PR corresponds to my [PR](https://github.com/gofrp/frp-doc/pull/89) that upgrades the site to latest version of docsy theme:

https://github.com/gofrp/frp-doc/pull/89